### PR TITLE
Update error handling

### DIFF
--- a/libs/zipkin/src/lib/zipkin-http-interceptor.ts
+++ b/libs/zipkin/src/lib/zipkin-http-interceptor.ts
@@ -1,7 +1,7 @@
-import { HttpClient, HttpEvent, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
+import { HttpEvent, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 
-import { of } from 'rxjs';
+import { throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import * as zipkin from 'zipkin';
 import { Tracer } from 'zipkin';
@@ -64,9 +64,9 @@ export class ZipkinHttpInterceptor extends TracingHttpInterceptor<ZipkinTraceRoo
           httpClient.recordResponse(traceId, event.status.toString());
         }
       }),
-      catchError((err: any, caught: any) => {
+      catchError((err: any) => {
         httpClient.recordError(traceId, err);
-        return of(caught);
+        return throwError(err);
       })
     );
   }


### PR DESCRIPTION
Instead of returning an observable of error, we should be throwing an error, otherwise, any subsequent observable streams are not able to catch the error and hang. 